### PR TITLE
[ci_stats] Add Buildkite CI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ or storing in Github.
 There are a lot of options you can use to customize what is included in the
 report.
 
+In addition to GitHub Actions, `ci_stats.rb` can also fetch and report on failed
+builds from Buildkite.
+
 ## Meeting Stats
 
 Many open source projects have weekly meetings and it's important to know
@@ -151,11 +154,23 @@ $ promises.rb
 You likely will probably want a config file for this as well and a sample
 is provided in [examples/promises_config.rb](examples/promises_config.rb).
 
-## Your GitHub Token
+## API Tokens
+
+### GitHub Token
 
 Everything in this repo looks for your GitHub Access Token in the following
 places, in order:
 
 1. The `--github-token` command-line argument
-1. The `$GITHUB_TOKEN` environment variable
-1. It'll also parse it from `~/.config/gh/hosts.yml` if you use `gh`.
+1. The `github_token` config file entry
+1. The `GITHUB_TOKEN` environment variable.
+1. It'll also parse it from `~/.config/gh/hosts.yml` if you use the `gh` CLI tool.
+
+### Buildkite Token
+
+Everything in this repo looks for your BuildKite API token in the following
+places, in order:
+
+1. The `--buildkite-token` command-line argument
+1. The `buildkite-token` config file entry
+1. The `BUILDKITE_API_TOKEN` environment variable.

--- a/spec/buildkite_client_spec.rb
+++ b/spec/buildkite_client_spec.rb
@@ -1,0 +1,171 @@
+require_relative '../src/lib/oss_stats/buildkite_client'
+require_relative '../src/lib/oss_stats/log'
+require 'date'
+
+RSpec.describe OssStats::BuildkiteClient do
+  let(:token) { 'test-token' }
+  let(:organization_slug) { 'test-org' }
+  let(:client) { described_class.new(token, organization_slug) }
+
+  describe '#get_pipeline_builds' do
+    let(:pipeline_slug) { 'test-pipeline' }
+    let(:pull_request_id) { '123' }
+    let(:from_date) { Date.new(2024, 1, 1) }
+    let(:to_date) { Date.new(2024, 1, 31) }
+
+    context 'when the API returns builds' do
+      let(:mock_api_response) do
+        {
+          'data' => {
+            'pipeline' => {
+              'builds' => {
+                'edges' => [
+                  {
+                    'node' => {
+                      'state' => 'PASSED',
+                    },
+                  },
+                  {
+                    'node' => {
+                      'state' => 'FAILED',
+                    },
+                  },
+                ],
+                'pageInfo' => {
+                  'hasNextPage' => false,
+                  'endCursor' => nil,
+                },
+              },
+            },
+          },
+        }
+      end
+
+      before do
+        # Mock the execute_graphql_query method
+        allow(client).to receive(:execute_graphql_query)
+          .and_return(mock_api_response)
+      end
+
+      it 'returns a list of builds with their job statuses' do
+        builds = client.get_pipeline_builds(
+          pipeline_slug, pull_request_id, from_date, to_date
+        )
+
+        expect(builds.size).to eq(2)
+        expect(builds[0]['node']['state']).to eq('PASSED')
+        expect(builds[1]['node']['state']).to eq('FAILED')
+      end
+    end
+
+    context 'when the API response is paginated' do
+      let(:mock_api_response_page1) do
+        {
+          'data' => {
+            'pipeline' => {
+              'builds' => {
+                'edges' => [
+                  { 'node' => { 'state' => 'PASSED' } },
+                ],
+                'pageInfo' => {
+                  'hasNextPage' => true, 'endCursor' => 'cursor1'
+                },
+              },
+            },
+          },
+        }
+      end
+      let(:mock_api_response_page2) do
+        {
+          'data' => {
+            'pipeline' => {
+              'builds' => {
+                'edges' => [
+                  { 'node' => { 'state' => 'FAILED'  } },
+                ],
+                'pageInfo' => { 'hasNextPage' => false, 'endCursor' => nil },
+              },
+            },
+          },
+        }
+      end
+
+      before do
+        # Mock execute_graphql_query to return page 1 then page 2
+        allow(client).to receive(:execute_graphql_query)
+          .and_return(mock_api_response_page1, mock_api_response_page2)
+      end
+
+      it 'fetches all builds across pages' do
+        builds = client.get_pipeline_builds(
+          pipeline_slug, pull_request_id, from_date, to_date
+        )
+        expect(builds.size).to eq(2)
+        expect(builds[0]['node']['state']).to eq('PASSED')
+        expect(builds[1]['node']['state']).to eq('FAILED')
+      end
+
+      it 'makes two API calls' do
+        expect(client).to receive(:execute_graphql_query).twice
+        client.get_pipeline_builds(
+          pipeline_slug, pull_request_id, from_date, to_date
+        )
+      end
+    end
+
+    context 'when the API call fails' do
+      before do
+        allow(client).to receive(:execute_graphql_query)
+          .and_raise(StandardError.new('API Error'))
+        allow(OssStats::Log).to receive(:error)
+      end
+
+      it 'returns an empty array' do
+        builds = client.get_pipeline_builds(
+          pipeline_slug, pull_request_id, from_date, to_date
+        )
+        expect(builds).to be_empty
+      end
+
+      it 'logs the error' do
+        expected_log_message =
+          %r{Error in get_pipeline_builds for slug test-org/test-pipeline}
+        expect(OssStats::Log).to receive_message_chain(:error)
+          .with(expected_log_message)
+        client.get_pipeline_builds(
+          pipeline_slug, pull_request_id, from_date, to_date
+        )
+      end
+    end
+
+    context 'when the API returns no builds' do
+      let(:mock_api_response) do
+        {
+          'data' => {
+            'pipeline' => {
+              'builds' => {
+                'edges' => [],
+                'pageInfo' => {
+                  'hasNextPage' => false,
+                  'endCursor' => nil,
+                },
+              },
+            },
+          },
+        }
+      end
+
+      before do
+        allow(client).to receive(:execute_graphql_query)
+          .and_return(mock_api_response)
+      end
+
+      it 'returns an empty array' do
+        builds = client.get_pipeline_builds(
+          pipeline_slug, pull_request_id, from_date, to_date
+        )
+        expect(builds).to be_empty
+      end
+    end
+  end
+end

--- a/spec/ci_stats_spec.rb
+++ b/spec/ci_stats_spec.rb
@@ -1,7 +1,9 @@
 require 'rspec'
 require 'octokit'
+require 'base64'
 require_relative '../src/ci_stats'
 require_relative '../src/lib/oss_stats/ci_stats_config'
+require_relative '../src/lib/oss_stats/log'
 
 RSpec.describe 'ci_status' do
   let(:client) { instance_double(Octokit::Client) }
@@ -100,6 +102,8 @@ RSpec.describe 'ci_status' do
 
   describe '#get_failed_tests_from_ci' do
     it 'fetches failed tests from CI workflows' do
+      allow(client).to receive(:readme).with('test_org/test_repo')
+                                       .and_return(double(content: ''))
       allow(client).to receive(:workflows).and_return(
         double(workflows: [double(id: 1, name: 'Test Workflow')]),
       )
@@ -130,6 +134,8 @@ RSpec.describe 'ci_status' do
     end
 
     it 'handles no failures gracefully' do
+      allow(client).to receive(:readme).with('test_org/test_repo')
+                                       .and_return(double(content: ''))
       allow(client).to receive(:workflows).and_return(
         double(workflows: [double(id: 1, name: 'Test Workflow')]),
       )
@@ -140,6 +146,352 @@ RSpec.describe 'ci_status' do
       failed_tests = get_failed_tests_from_ci(client, options)
 
       expect(failed_tests['main']).to be_empty
+    end
+
+    describe 'Buildkite Integration' do
+      let(:mock_buildkite_client) { instance_double(OssStats::BuildkiteClient) }
+      # Updated README content to match the new regex
+      let(:readme_content_with_badge) do
+        badge1 = 'https://badge.buildkite.com/someuuid.svg?branch=main'
+        url1 = 'https://buildkite.com/test-buildkite-org/actual-pipeline-name'
+        badge2 = 'https://badge.buildkite.com/another.svg'
+        url2 = 'https://buildkite.com/other-org/other-pipeline'
+        Base64.encode64(
+          <<~README,
+          Some text before
+          [![Build Status](#{badge1})](#{url1})
+          More text [![Another Badge](#{badge2})](#{url2})
+          Some text after
+          README
+        )
+      end
+      let(:readme_content_with_badge_alternative_format) do
+        # Test with a slightly different markdown image link format
+        badge = 'https://badge.buildkite.com/short-uuid.svg'
+        url = 'https://buildkite.com/test-buildkite-org/another-actual-pipeline'
+        Base64.encode64(
+          <<~README,
+          [![] (#{badge})](#{url})
+          README
+        )
+      end
+      let(:readme_content_without_badge) do
+        Base64.encode64('This README has no Buildkite badge, only text.')
+      end
+      let(:settings_with_buildkite_token) do
+        options.merge(buildkite_token: 'fake-bk-token')
+      end
+
+      before do
+        allow(self).to receive(:get_buildkite_token!)
+          .with(OssStats::CiStatsConfig).and_return('fake-bk-token')
+        allow(OssStats::BuildkiteClient).to receive(:new)
+          .and_return(mock_buildkite_client)
+        allow(mock_buildkite_client).to receive(:get_pipeline_builds)
+          .and_return([])
+      end
+
+      context 'when repository has a Buildkite badge in README' do
+        let(:readme_double) { double(content: readme_content_with_badge) }
+        let(:repo_full_name) { "#{options[:org]}/#{options[:repo]}" }
+
+        before do
+          allow(client).to receive(:readme)
+            .with(repo_full_name)
+            .and_return(readme_double)
+        end
+
+        it 'calls BuildkiteClient with correct slugs and processes results' do
+          expect(OssStats::BuildkiteClient).to receive(:new)
+            .with('fake-bk-token', 'test-buildkite-org')
+            .and_return(mock_buildkite_client)
+          expect(mock_buildkite_client).to receive(:get_pipeline_builds)
+            .with(
+              'actual-pipeline-name',
+              nil,
+              Date.today - options[:days],
+              Date.today,
+            )
+            .and_return([
+              {
+                'node' => {
+                  'createdAt' => (Date.today - 1).to_s, 'state' => 'FAILED'
+                },
+              },
+            ])
+          failed_tests = get_failed_tests_from_ci(
+            client, settings_with_buildkite_token
+          )
+          job1_key = '[BK] test-buildkite-org/actual-pipeline-name'
+          expect(failed_tests['main'][job1_key]).to include(Date.today - 1)
+        end
+
+        it 'correctly parses alternative badge markdown format' do
+          allow(client).to receive(:readme)
+            .with(repo_full_name)
+            .and_return(
+              double(content: readme_content_with_badge_alternative_format),
+            )
+          expect(OssStats::BuildkiteClient).to receive(:new)
+            .with('fake-bk-token', 'test-buildkite-org')
+            .and_return(mock_buildkite_client)
+          expect(mock_buildkite_client).to receive(:get_pipeline_builds)
+            .with(
+              'another-actual-pipeline',
+              nil,
+              Date.today - options[:days],
+              Date.today,
+            )
+            .and_return([])
+          get_failed_tests_from_ci(client, settings_with_buildkite_token)
+        end
+
+        it 'handles no failed builds from Buildkite' do
+          allow(mock_buildkite_client).to receive(:get_pipeline_builds)
+            .and_return([
+              {
+                'node' => {
+                  'createdAt' => (Date.today - 1).to_s,
+                  'state' => 'PASSED',
+                  'jobs' => {
+                    'edges' => [
+                      {
+                        'node' => {
+                          'label' => 'Test Job 1', 'state' => 'PASSED'
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            ])
+          failed_tests = get_failed_tests_from_ci(
+            client, settings_with_buildkite_token
+          )
+          buildkite_job_keys = failed_tests['main'].keys.select do |k|
+            k.start_with?('Buildkite /')
+          end
+          expect(buildkite_job_keys).to be_empty
+        end
+
+        context 'with ongoing failures' do
+          let(:days_to_check) { 5 }
+          let(:options_for_ongoing) { options.merge(days: days_to_check) }
+          let(:today) { Date.today }
+          let(:pipeline_name) { 'actual-pipeline-name' }
+          let(:job_key) { "[BK] test-buildkite-org/#{pipeline_name}" }
+
+          let(:mock_builds_for_ongoing_test) do
+            # Helper to create a build node
+            def build_node(created_at_val, state_val)
+              {
+                'node' => {
+                  'createdAt' => created_at_val.to_s,
+                  'state' => state_val,
+                },
+              }
+            end
+
+            [
+              build_node(today - days_to_check + 1, 'FAILED'),
+              build_node(today - days_to_check + 2, 'FAILED'),
+              build_node(today - days_to_check + 3, 'PASSED'),
+              build_node(today - days_to_check + 4, 'FAILED'),
+            ].sort_by { |b| DateTime.parse(b['node']['createdAt']) }
+          end
+
+          it 'correctly reports days for ongoing and fixed failures' do
+            allow(mock_buildkite_client).to receive(:get_pipeline_builds)
+              .with(pipeline_name, nil, today - days_to_check, today)
+              .and_return(mock_builds_for_ongoing_test)
+
+            failed_tests = get_failed_tests_from_ci(client, options_for_ongoing)
+
+            expected_job_dates = Set.new([
+              today - days_to_check + 1,
+              today - days_to_check + 2,
+              # no 3, it passed that day
+              today - days_to_check + 4,
+              # add today (days_to_check = 5), becuase we fill in
+              # all days through today if the last check is failing
+              today,
+            ])
+            expect(failed_tests['main'][job_key]).to eq(expected_job_dates)
+            expect(failed_tests['main'][job_key].size).to eq(days_to_check - 1)
+          end
+        end
+      end
+
+      context 'when repository does not have a Buildkite badge' do
+        before do
+          allow(client).to receive(:readme)
+            .with("#{options[:org]}/#{options[:repo]}")
+            .and_return(double(content: readme_content_without_badge))
+        end
+
+        it 'does not call BuildkiteClient' do
+          expect(OssStats::BuildkiteClient).not_to receive(:new)
+          expect(mock_buildkite_client).not_to receive(:get_pipeline_builds)
+          get_failed_tests_from_ci(client, settings_with_buildkite_token)
+        end
+      end
+
+      context 'when README is not found' do
+        it 'handles the error and does not call BuildkiteClient' do
+          allow(client).to receive(:readme)
+            .with("#{options[:org]}/#{options[:repo]}")
+            .and_raise(Octokit::NotFound)
+          expect(OssStats::BuildkiteClient).not_to receive(:new)
+          expect(OssStats::Log).to receive(:warn)
+            .with(%r{README.md not found for repo test_org/test_repo})
+          get_failed_tests_from_ci(client, settings_with_buildkite_token)
+        end
+      end
+
+      context 'when Buildkite API call fails' do
+        before do
+          allow(client).to receive(:readme)
+            .with("#{options[:org]}/#{options[:repo]}")
+            .and_return(double(content: readme_content_with_badge))
+          allow(mock_buildkite_client)
+            .to receive(:get_pipeline_builds)
+            .and_raise(StandardError.new('Buildkite API Error'))
+        end
+
+        it 'handles the error gracefully and logs it' do
+          expect(OssStats::Log).to receive(:error)
+            .with(/Error during Buildkite integration for test_org/)
+          failed_tests = get_failed_tests_from_ci(
+            client, settings_with_buildkite_token
+          )
+          buildkite_job_keys = failed_tests['main'].keys.select do |k|
+            k.start_with?('Buildkite /')
+          end
+          expect(buildkite_job_keys).to be_empty
+        end
+      end
+
+      context 'when Buildkite token is not available' do
+        before do
+          # Mock get_buildkite_token! to return nil
+          allow(self).to receive(:get_buildkite_token!)
+            .and_raise(ArgumentError)
+          allow(client).to receive(:readme)
+            .with("#{options[:org]}/#{options[:repo]}")
+            .and_return(double(content: readme_content_with_badge))
+        end
+      end
+    end
+  end
+end
+
+describe '#print_ci_status' do
+  context 'with only GitHub Actions failures' do
+    let(:test_failures) do
+      {
+        'main' => {
+          'GH Workflow / Job A' => Set[Date.today, Date.today - 1],
+          'GH Workflow / Job B' => Set[Date.today],
+        },
+      }
+    end
+
+    it 'prints GitHub Actions failures correctly' do
+      expect(OssStats::Log).to receive(:info)
+        .with("\n* CI Stats:")
+      expect(OssStats::Log).to receive(:info)
+        .with('    * Branch: `main` has the following failures:')
+      expect(OssStats::Log).to receive(:info)
+        .with('        * GH Workflow / Job A: 2 days')
+      expect(OssStats::Log).to receive(:info)
+        .with('        * GH Workflow / Job B: 1 days')
+      print_ci_status(test_failures)
+    end
+  end
+
+  context 'with only Buildkite failures' do
+    let(:test_failures) do
+      {
+        'main' => {
+          '[BK] org/pipe1' => Set[Date.today],
+          '[BK] org/pipe2' => Set[Date.today, Date.today - 1, Date.today - 2],
+        },
+      }
+    end
+
+    it 'prints Buildkite failures correctly' do
+      expect(OssStats::Log).to receive(:info)
+        .with("\n* CI Stats:")
+      expect(OssStats::Log).to receive(:info)
+        .with('    * Branch: `main` has the following failures:')
+      expect(OssStats::Log).to receive(:info)
+        .with('        * [BK] org/pipe1: 1 days')
+      expect(OssStats::Log).to receive(:info)
+        .with('        * [BK] org/pipe2: 3 days')
+      print_ci_status(test_failures)
+    end
+  end
+
+  context 'with mixed GitHub Actions and Buildkite failures' do
+    let(:test_failures) do
+      {
+        'main' => {
+          'GH Workflow / Job A' => Set[Date.today],
+          'Buildkite / org/pipe / Job X' => Set[Date.today - 1],
+          'GH Workflow / Job C' => Set[Date.today - 2, Date.today - 3],
+        },
+      }
+    end
+
+    it 'prints mixed failures correctly and sorted' do
+      expect(OssStats::Log).to receive(:info)
+        .with("\n* CI Stats:")
+      expect(OssStats::Log).to receive(:info)
+        .with('    * Branch: `main` has the following failures:')
+      # Sorted order: Buildkite job first, then GH jobs
+      expect(OssStats::Log).to receive(:info)
+        .with('        * Buildkite / org/pipe / Job X: 1 days').ordered
+      expect(OssStats::Log).to receive(:info)
+        .with('        * GH Workflow / Job A: 1 days').ordered
+      expect(OssStats::Log).to receive(:info)
+        .with('        * GH Workflow / Job C: 2 days').ordered
+      print_ci_status(test_failures)
+    end
+  end
+
+  context 'with no failures' do
+    let(:test_failures) { { 'main' => {} } }
+
+    it 'prints the no failures message' do
+      expect(OssStats::Log).to receive(:info)
+        .with("\n* CI Stats:")
+      expect(OssStats::Log).to receive(:info)
+        .with('    * Branch: `main`: No job failures found! :tada:')
+      print_ci_status(test_failures)
+    end
+  end
+
+  context 'with failures on multiple branches' do
+    let(:test_failures) do
+      {
+        'main' => { 'GH Workflow / Job A' => Set[Date.today] },
+        'develop' => { '[BK] org/pipe' => Set[Date.today - 1, Date.today - 2] },
+      }
+    end
+
+    it 'groups failures by branch and prints them correctly' do
+      expect(OssStats::Log).to receive(:info)
+        .with("\n* CI Stats:")
+      expect(OssStats::Log).to receive(:info)
+        .with('    * Branch: `develop` has the following failures:')
+      expect(OssStats::Log).to receive(:info)
+        .with('        * [BK] org/pipe: 2 days')
+      expect(OssStats::Log).to receive(:info)
+        .with('    * Branch: `main` has the following failures:')
+      expect(OssStats::Log).to receive(:info)
+        .with('        * GH Workflow / Job A: 1 days')
+
+      print_ci_status(test_failures)
     end
   end
 end

--- a/src/lib/oss_stats/buildkite_token.rb
+++ b/src/lib/oss_stats/buildkite_token.rb
@@ -1,13 +1,15 @@
 def get_buildkite_token(options)
-  options[:buildkite_token] || ENV['BUILDKITE_TOKEN'] || nil
+  return options[:buildkite_token] if options[:buildkite_tokne]
+  return ENV['BUILDKITE_API_TOKEN'] if ENV['BUILDKITE_API_TOKEN']
+  nil
 end
 
-def get_buildkite_token!(options)
-  token = get_buildkite_token(options)
+def get_buildkite_token!(config = OssStats::CiStatsConfig)
+  token = get_buildkite_token(config)
   unless token
     raise ArgumentError,
-      'Buildkite token not found. Pass with --buildkite-token or set ' +
-      'BUILDKITE_TOKEN env var.'
+      'Buildkite token not found. Set via --buildkite-token CLI option, ' +
+      'in ci_stats_config.rb, or as BUILDKITE_API_TOKEN environment variable.'
   end
   token
 end

--- a/src/lib/oss_stats/ci_stats_config.rb
+++ b/src/lib/oss_stats/ci_stats_config.rb
@@ -11,6 +11,7 @@ module OssStats
     ci_timeout 600
     github_api_endpoint nil
     github_token nil
+    buildkite_token nil
     limit_gh_ops_per_minute nil
     include_list false
     organizations {}

--- a/src/lib/oss_stats/github_token.rb
+++ b/src/lib/oss_stats/github_token.rb
@@ -15,8 +15,9 @@ end
 def get_github_token!(options)
   token = get_github_token(options)
   unless token
-    raise 'GitHub token is missing. Please provide a token using ' +
-          '--github-token, or set $GITHUB_TOKEN, or run `gh auth login`'
+    raise ArgumentError,
+      'GitHub token is missing. Please provide a token using ' +
+      '--github-token, or set $GITHUB_TOKEN, or run `gh auth login`'
   end
   token
 end


### PR DESCRIPTION
Integrates Buildkite CI into the `ci_stats` tool, allowing it to report on
test failures from Buildkite pipelines alongside existing GitHub Actions support.

This is a first pass, at the moment it simply looks for a badge in the
README that points to a buildkite build, and then checks that. More to
come soon.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
