### PR TITLE
Link to builds/pipelines/workflows; Fix org/repo limiting

### DIFF
--- a/lib/oss_stats/buildkite_client.rb
+++ b/lib/oss_stats/buildkite_client.rb
@@ -25,6 +25,7 @@ module OssStats
         query {
           pipeline(slug: "#{org}/#{pipeline}") {
             visibility
+            url
           }
         }
       GRAPHQL
@@ -74,6 +75,7 @@ module OssStats
                       url
                     }
                     visibility
+                    url
                   }
                 }
                 pageInfo {
@@ -115,6 +117,7 @@ module OssStats
 
         pipelines_by_repo[repo_url] << {
           slug: pipeline['slug'],
+          url: pipeline['url'],
           visibility: pipeline['visibility'],
         }
       end
@@ -134,6 +137,7 @@ module OssStats
     #   'createdAt', and 'jobs'.
     #   Returns an empty array if an error occurs or no builds are found.
     def get_pipeline_builds(org, pipeline, from_date, to_date, branch = 'main')
+      log.debug("get_pipeline_builds: #{org}, #{pipeline}")
       all_build_edges = []
       after_cursor = nil
       has_next_page = true

--- a/lib/oss_stats/config/repo_stats.rb
+++ b/lib/oss_stats/config/repo_stats.rb
@@ -13,6 +13,7 @@ module OssStats
       default_days 30
       log_level :info
       ci_timeout 600
+      no_links false
       github_api_endpoint nil
       github_token nil
       github_org nil


### PR DESCRIPTION
* Keep track of URLs so we can link to them
* Add a --no-links option to prevent links
* PR #52 added limiting of orgs/repos, but accidentally didn't
  _use_ the results, fixed that

Closes #53

Signed-off-by: Phil Dibowitz <phil@ipom.com>
