### PR TITLE
Update --branches/--default-branches to match --days/--default-days

### DIFF
--- a/examples/repo_stats_config.rb
+++ b/examples/repo_stats_config.rb
@@ -3,6 +3,9 @@
 # You can specify branches for specific repos under 'organizations'
 # below, but for anything not specified it'll use `default_branches`
 # (which defaults to ['main'])
+#
+# Note do NOT set 'days' or 'branches' in your config, as that overrides
+# everything and is meant for CLI options.
 default_branches %w{main v2}
 default_days 30
 # you can specify 'days', but it will override everything, including

--- a/lib/oss_stats/config/repo_stats.rb
+++ b/lib/oss_stats/config/repo_stats.rb
@@ -7,10 +7,14 @@ module OssStats
       extend Mixlib::Config
       extend OssStats::Config::Shared
 
-      # generally this shouldn't be set, it overrides everything
+      # generally these should NOT be set, they override everything
       days nil
+      branches nil
+
+      # set these instead
       default_branches ['main']
       default_days 30
+
       log_level :info
       ci_timeout 600
       no_links false

--- a/spec/repo_stats_spec.rb
+++ b/spec/repo_stats_spec.rb
@@ -646,6 +646,7 @@ RSpec.describe 'repo_stats' do
   describe '#get_effective_repo_settings' do
     before(:each) do
       OssStats::Config::RepoStats.days = nil
+      OssStats::Config::RepoStats.branches = nil
       OssStats::Config::RepoStats.default_days = 15
       OssStats::Config::RepoStats.default_branches = ['foo']
     end
@@ -702,6 +703,20 @@ RSpec.describe 'repo_stats' do
         expect(s[:days]).to eq(11)
         # most specific branches setting is from repo
         expect(s[:branches]).to eq(['special'])
+      end
+
+      it 'overrides default org and repo with cli branches settings' do
+        OssStats::Config::RepoStats.branches = ['somebranch']
+        s = get_effective_repo_settings(
+          'org1',
+          'repo1',
+          { 'days' => 77, 'branches' => ['release'] },
+          { 'days' => 99, 'branches' => ['special'] },
+        )
+        # days comes from CLI override
+        expect(s[:days]).to eq(99)
+        # most specific branches setting is from repo
+        expect(s[:branches]).to eq(['somebranch'])
       end
     end
   end


### PR DESCRIPTION
Give users the ability to do one-off runs on just specific branches.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
